### PR TITLE
sepolicy: Exclude debug sepolicies on user build

### DIFF
--- a/SEPolicy.mk
+++ b/SEPolicy.mk
@@ -13,19 +13,27 @@ endif
 
 BOARD_VENDOR_SEPOLICY_DIRS += \
     $(MTK_SEPOLICY_PATH)/basic/non_plat \
-    $(MTK_SEPOLICY_PATH)/basic/debug/non_plat \
     $(MTK_SEPOLICY_PATH)/bsp/non_plat \
-    $(MTK_SEPOLICY_PATH)/bsp/debug/non_plat \
     $(MTK_SEPOLICY_PATH)/modem
 
 SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += \
     $(MTK_SEPOLICY_PATH)/basic/plat_private \
-    $(MTK_SEPOLICY_PATH)/basic/debug/plat_private \
     $(MTK_SEPOLICY_PATH)/bsp/plat_private \
-    $(MTK_SEPOLICY_PATH)/bsp/debug/plat_private
 
 SYSTEM_EXT_PUBLIC_SEPOLICY_DIRS += \
     $(MTK_SEPOLICY_PATH)/basic/plat_public \
-    $(MTK_SEPOLICY_PATH)/basic/debug/plat_public \
     $(MTK_SEPOLICY_PATH)/bsp/plat_public \
+
+ifneq ($(TARGET_BUILD_VARIANT),user)
+BOARD_VENDOR_SEPOLICY_DIRS += \
+    $(MTK_SEPOLICY_PATH)/bsp/debug/non_plat \
+    $(MTK_SEPOLICY_PATH)/basic/debug/non_plat
+
+SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += \
+    $(MTK_SEPOLICY_PATH)/basic/debug/plat_private \
+    $(MTK_SEPOLICY_PATH)/bsp/debug/plat_private
+
+SYSTEM_EXT_PUBLIC_SEPOLICY_DIRS += \
+    $(MTK_SEPOLICY_PATH)/basic/debug/plat_public \
     $(MTK_SEPOLICY_PATH)/bsp/debug/plat_public
+endif

--- a/basic/non_plat/update_engine.te
+++ b/basic/non_plat/update_engine.te
@@ -5,7 +5,6 @@
 # Add for update_engine update block device
 allow update_engine preloader_block_device:blk_file rw_file_perms;
 allow update_engine lk_block_device:blk_file rw_file_perms;
-allow update_engine dtbo_block_device:blk_file rw_file_perms;
 allow update_engine tee_block_device:blk_file rw_file_perms;
 allow update_engine vendor_block_device:blk_file rw_file_perms;
 allow update_engine odm_block_device:blk_file rw_file_perms;

--- a/bsp/debug/plat_private/system_server.te
+++ b/bsp/debug/plat_private/system_server.te
@@ -5,3 +5,10 @@ allow system_server crash_dump:unix_stream_socket connectto;
 # Date:2020/12/23
 # Operation:R Migration, add permission for AMS read mtk_AEE_prop
 get_prop(system_server, system_mtk_persist_aee_prop)
+
+# Date:2020/09/04
+# Operation:R Migration, add permission for AMS dump binderinfo when ANR happened in user load
+allow system_server binderfs_logs:dir r_dir_perms;
+allow system_server binderfs_logs:file r_file_perms;
+allow system_server binderfs_logs_proc:dir r_dir_perms;
+allow system_server binderfs_logs_proc:file r_file_perms;

--- a/bsp/plat_private/system_server.te
+++ b/bsp/plat_private/system_server.te
@@ -151,13 +151,6 @@ allow system_server app_zygote:process getpgid;
 # Operation:R Migration
 allow system_server installd:process signal;
 
-# Date:2020/09/04
-# Operation:R Migration, add permission for AMS dump binderinfo when ANR happened in user load
-allow system_server binderfs_logs:dir r_dir_perms;
-allow system_server binderfs_logs:file r_file_perms;
-allow system_server binderfs_logs_proc:dir r_dir_perms;
-allow system_server binderfs_logs_proc:file r_file_perms;
-
 # Date:2020/09/24
 # Operation:R Migration, add permission for PMS access /data/media
 allow system_server media_rw_data_file:dir setattr;


### PR DESCRIPTION
also move system_server binderfs_logs rule to debug sepolicy causes neverallow for:
      (allow system_server binderfs_logs_proc (file (ioctl read getattr lock map open watch watch_reads)))
      (allow system_server binderfs_logs (file (ioctl read getattr lock map open watch watch_reads)))
      (allow aee_aedv binderfs_logs (file (ioctl read getattr lock map open watch watch_reads)))

besides, why even include include these on user build

Change-Id: I76a43816185c98e08e0439cd29d3f7a3325ca795